### PR TITLE
refactor: 新規会員登録におけるContainer/Presentationalパターンの実装

### DIFF
--- a/app/_components/auth/register/Register.tsx
+++ b/app/_components/auth/register/Register.tsx
@@ -8,9 +8,10 @@ import { FieldValues, useForm, SubmitHandler } from "react-hook-form";
 import { z } from "zod";
 import authAPI from "@/app/_api/auth/auth-api";
 import { useRouter } from "next/navigation";
-import CustomInput from "../common/CustomInput";
+
 import { useState } from "react";
 import { AuthRegisterResponse } from "@/app/type/auth";
+import CustomInput from "../../common/CustomInput";
 
 const schema = z.object({
   name: z.string().min(1, { message: "名前を入力してください" }),

--- a/app/_components/auth/register/RegisterForm.tsx
+++ b/app/_components/auth/register/RegisterForm.tsx
@@ -1,0 +1,80 @@
+import { Button, Container, Typography, Box } from "@mui/material";
+import CustomInput from "../../common/CustomInput";
+import { FieldValues, UseFormRegister, FormState } from "react-hook-form";
+
+type TProps = {
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  register: UseFormRegister<FieldValues>;
+  errors: FormState<FieldValues>["errors"];
+  loading: boolean;
+};
+
+const RegisterForm: React.FC<TProps> = ({
+  onSubmit,
+  register,
+  errors,
+  loading,
+}) => {
+  return (
+    <Container maxWidth="sm">
+      <Box
+        component={"form"}
+        display={"flex"}
+        flexDirection={"column"}
+        alignItems={"center"}
+        justifyContent={"center"}
+        mt={5}
+        onSubmit={onSubmit}
+      >
+        <Typography variant="h4" component="h1" gutterBottom>
+          Register
+        </Typography>
+        <CustomInput
+          id="name"
+          label="ユーザー名"
+          disabled={loading}
+          register={register}
+          errors={errors}
+          required
+        />
+        <CustomInput
+          id="email"
+          label="メールアドレス"
+          disabled={loading}
+          register={register}
+          errors={errors}
+          required
+        />
+        <CustomInput
+          id="password"
+          label="パスワード"
+          type="password"
+          disabled={loading}
+          register={register}
+          errors={errors}
+          required
+        />
+        <CustomInput
+          id="githubId"
+          label="GitHub ID"
+          disabled={loading}
+          register={register}
+          errors={errors}
+          required
+        />
+        <Button
+          type="submit"
+          fullWidth
+          variant="contained"
+          color="primary"
+          sx={{ mt: 3, mb: 2 }}
+          disabled={loading}
+        >
+          登録する
+        </Button>
+      </Box>
+    </Container>
+  );
+};
+
+export default RegisterForm;

--- a/app/_components/auth/register/RegisterFormContainer.tsx
+++ b/app/_components/auth/register/RegisterFormContainer.tsx
@@ -20,7 +20,7 @@ const schema = z.object({
   githubId: z.string().min(1, { message: "GitHub IDを入力してください" }),
 });
 
-const Register = () => {
+const RegisterFormContainer = () => {
   const [loading, setLoading] = useState(false);
   const router = useRouter();
 
@@ -139,4 +139,4 @@ const Register = () => {
   );
 };
 
-export default Register;
+export default RegisterFormContainer;

--- a/app/_components/auth/register/RegisterFormContainer.tsx
+++ b/app/_components/auth/register/RegisterFormContainer.tsx
@@ -1,17 +1,15 @@
 "use client";
-import { Button, Container, Typography, Box } from "@mui/material";
+import React, { useState } from "react";
+import { useRouter } from "next/navigation";
 import { useMutation } from "@tanstack/react-query";
-import { AxiosResponse } from "axios";
 import Cookies from "js-cookie";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { FieldValues, useForm, SubmitHandler } from "react-hook-form";
+import { useForm, FieldValues, SubmitHandler } from "react-hook-form";
 import { z } from "zod";
+import { AxiosResponse } from "axios";
 import authAPI from "@/app/_api/auth/auth-api";
-import { useRouter } from "next/navigation";
-
-import { useState } from "react";
 import { AuthRegisterResponse } from "@/app/type/auth";
-import CustomInput from "../../common/CustomInput";
+import RegisterForm from "./RegisterForm";
 
 const schema = z.object({
   name: z.string().min(1, { message: "名前を入力してください" }),
@@ -50,7 +48,7 @@ const RegisterFormContainer = () => {
       password: string;
       githubId: string;
     }) => authAPI.register(username, email, password, githubId),
-    onSuccess: (response: AxiosResponse<AuthRegisterResponse>) => {
+    onSuccess: (response) => {
       const token = response.data.token;
       Cookies.set("token", token);
       router.push("/dashboard");
@@ -77,65 +75,12 @@ const RegisterFormContainer = () => {
   };
 
   return (
-    // TODO: refactor to presentational components in other branch
-    <Container maxWidth="sm">
-      <Box
-        component="form"
-        display="flex"
-        flexDirection="column"
-        alignItems="center"
-        justifyContent="center"
-        mt={5}
-        onSubmit={handleSubmit(onSubmit)}
-      >
-        <Typography variant="h4" component="h1" gutterBottom>
-          Register
-        </Typography>
-        <CustomInput
-          id="name"
-          label="ユーザー名"
-          disabled={loading}
-          register={register}
-          errors={errors}
-          required
-        />
-        <CustomInput
-          id="email"
-          label="メールアドレス"
-          disabled={loading}
-          register={register}
-          errors={errors}
-          required
-        />
-        <CustomInput
-          id="password"
-          label="パスワード"
-          type="password"
-          disabled={loading}
-          register={register}
-          errors={errors}
-          required
-        />
-        <CustomInput
-          id="githubId"
-          label="GitHub ID"
-          disabled={loading}
-          register={register}
-          errors={errors}
-          required
-        />
-        <Button
-          type="submit"
-          fullWidth
-          variant="contained"
-          color="primary"
-          sx={{ mt: 3, mb: 2 }}
-          disabled={loading}
-        >
-          {loading ? "Registering..." : "Register"}
-        </Button>
-      </Box>
-    </Container>
+    <RegisterForm
+      onSubmit={handleSubmit(onSubmit)}
+      register={register}
+      errors={errors}
+      loading={loading}
+    />
   );
 };
 

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,11 @@
+import { Box, CircularProgress } from "@mui/material";
+
+const Loading = () => {
+  return (
+    <Box display="flex" alignItems="center" justifyContent="center">
+      <CircularProgress color="primary" />
+    </Box>
+  );
+};
+
+export default Loading;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import Register from "./_components/auth/Register";
+import Register from "./_components/auth/register/Register";
 
 const Page = () => {
   return <Register />;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,5 @@
-import RegisterFormContainer from "./_components/auth/register/RegisterFormContainer";
-
 const Page = () => {
-  return <RegisterFormContainer />;
+  return <div>home</div>;
 };
 
 export default Page;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
-import Register from "./_components/auth/register/Register";
+import RegisterFormContainer from "./_components/auth/register/RegisterFormContainer";
 
 const Page = () => {
-  return <Register />;
+  return <RegisterFormContainer />;
 };
 
 export default Page;

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,0 +1,7 @@
+import RegisterFormContainer from "../_components/auth/register/RegisterFormContainer";
+
+const Page = () => {
+  return <RegisterFormContainer />;
+};
+
+export default Page;


### PR DESCRIPTION
## やったこと
- loadingの作成
- viewとロジックを分けたコンポーネント分割

## やってないこと/別のブランチでやること
- ログインの実装
- 本気のUI/UXデザイン